### PR TITLE
Android security 11.0.0 release 75

### DIFF
--- a/drivers/staging/qcacld-3.0/sound/soc/msm/qdsp6v2/q6lsm.c
+++ b/drivers/staging/qcacld-3.0/sound/soc/msm/qdsp6v2/q6lsm.c
@@ -367,6 +367,10 @@ static int q6lsm_apr_send_pkt(struct lsm_client *client, void *handle,
 	struct apr_hdr *msg_hdr = (struct apr_hdr *) data;
 
 	pr_debug("%s: enter wait %d\n", __func__, wait);
+  if (mmap_handle_p) {
+    pr_debug("%s: Invalid mmap_handle\n", __func__);
+    return -EINVAL;
+  }
 	if (wait)
 		mutex_lock(&lsm_common.apr_lock);
 	if (mmap_p) {
@@ -410,6 +414,7 @@ static int q6lsm_apr_send_pkt(struct lsm_client *client, void *handle,
 	if (wait)
 		mutex_unlock(&lsm_common.apr_lock);
 
+  mmap_handle_p = NULL;
 	pr_debug("%s: leave ret %d\n", __func__, ret);
 	return ret;
 }
@@ -1384,6 +1389,8 @@ static int q6lsm_mmapcallback(struct apr_client_data *data, void *priv)
 		if (atomic_read(&client->cmd_state) == CMD_STATE_WAIT_RESP) {
 			spin_lock_irqsave(&mmap_lock, flags);
 			*mmap_handle_p = command;
+      if (mmap_handle_p)
+              *mmap_handle_p = command;
 			/* spin_unlock_irqrestore implies barrier */
 			spin_unlock_irqrestore(&mmap_lock, flags);
 			atomic_set(&client->cmd_state, CMD_STATE_CLEARED);

--- a/sound/soc/msm/qdsp6v2/q6lsm.c
+++ b/sound/soc/msm/qdsp6v2/q6lsm.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2016, 2019 Linux Foundation. All rights reserved.
+ * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -372,6 +373,10 @@ static int q6lsm_apr_send_pkt(struct lsm_client *client, void *handle,
 	struct apr_hdr *msg_hdr = (struct apr_hdr *) data;
 
 	pr_debug("%s: enter wait %d\n", __func__, wait);
+  if (mmap_handle_p) {
+    pr_debug("%s: Invalid mmap_handle\n", __func__);
+    return -EINVAL;
+  }
 	if (wait)
 		mutex_lock(&lsm_common.apr_lock);
 	if (mmap_p) {
@@ -415,6 +420,7 @@ static int q6lsm_apr_send_pkt(struct lsm_client *client, void *handle,
 	if (wait)
 		mutex_unlock(&lsm_common.apr_lock);
 
+  mmap_handle_p = NULL;
 	pr_debug("%s: leave ret %d\n", __func__, ret);
 	return ret;
 }
@@ -1390,7 +1396,8 @@ static int q6lsm_mmapcallback(struct apr_client_data *data, void *priv)
 	case LSM_SESSION_CMDRSP_SHARED_MEM_MAP_REGIONS:
 		if (atomic_read(&client->cmd_state) == CMD_STATE_WAIT_RESP) {
 			spin_lock_irqsave(&mmap_lock, flags);
-			*mmap_handle_p = command;
+      if (mmap_handle_p)
+              *mmap_handle_p = command;
 			/* spin_unlock_irqrestore implies barrier */
 			spin_unlock_irqrestore(&mmap_lock, flags);
 			atomic_set(&client->cmd_state, CMD_STATE_CLEARED);


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r75' of https://github.com/st-schilling/android_kernel_motorola_sanders into arrow-11.0

A-303101456: 
- https://git.codelinaro.org/clo/la/platform/vendor/opensource/audio-kernel/-/commit/6b8f3568740661978d7d60567ff5e27b5fb7d28d
- https://git.codelinaro.org/clo/la/platform/vendor/opensource/audio-kernel/-/commit/cbc7de440c37338738d182c82548d3c6ea001dc1
- https://git.codelinaro.org/clo/la/kernel/msm-4.4/-/commit/ca9d5a4f888f77ed54bd821f0ebbb5b2215c319b


The global declared mmap_handle can be left dangling for case when the handle is freed by the calling function. Fix is to address this. Also add a check to make sure the mmap_handle is accessed legally.

Change-Id: I367f8a41339aa0025b545b125ee820220efedeee